### PR TITLE
Adhere ViewHolder pattern

### DIFF
--- a/app/src/main/java/com/antonioleiva/weatherapp/ui/adapters/ForecastListAdapter.kt
+++ b/app/src/main/java/com/antonioleiva/weatherapp/ui/adapters/ForecastListAdapter.kt
@@ -28,13 +28,18 @@ class ForecastListAdapter(val weekForecast: ForecastList, val itemClick: (Foreca
 
     class ViewHolder(view: View, val itemClick: (Forecast) -> Unit) : RecyclerView.ViewHolder(view) {
 
+        val dateView = itemView.date
+        val descriptionView = itemView.description
+        val maxTemperatureView = itemView.maxTemperature
+        val minTemperatureView = itemView.minTemperature
+
         fun bindForecast(forecast: Forecast) {
             with(forecast) {
                 Picasso.with(itemView.ctx).load(iconUrl).into(itemView.icon)
-                itemView.date.text = date.toDateString()
-                itemView.description.text = description
-                itemView.maxTemperature.text = "${high}º"
-                itemView.minTemperature.text = "${low}º"
+                dateView.text = date.toDateString()
+                descriptionView.text = description
+                maxTemperatureView.text = "${high}º"
+                minTemperatureView.text = "${low}º"
                 itemView.setOnClickListener { itemClick(this) }
             }
         }


### PR DESCRIPTION
Hi, I found that your code seems violate `ViewHolder` pattern. Please take a look at the following bytecode. `findViewById` is called each time when `bindForecast` is called.

```
public static final class ViewHolder extends android.support.v7.widget.RecyclerView.ViewHolder {
      @NotNull
      private final Function1 itemClick;

      public final void bindForecast(@NotNull Forecast forecast) {
         Intrinsics.checkParameterIsNotNull(forecast, "forecast");
         Picasso.with(ViewExtensionsKt.getCtx(this.itemView)).load(forecast.getIconUrl()).into((ImageView)this.itemView.findViewById(id.icon));
         ((TextView)this.itemView.findViewById(id.date)).setText((CharSequence)ExtensionUtilsKt.toDateString$default(forecast.getDate(), 0, 1, (Object)null));
         ((TextView)this.itemView.findViewById(id.description)).setText((CharSequence)forecast.getDescription());
         ((TextView)this.itemView.findViewById(id.maxTemperature)).setText((CharSequence)(forecast.getHigh() + "º"));
         ((TextView)this.itemView.findViewById(id.minTemperature)).setText((CharSequence)(forecast.getLow() + "º"));
         this.itemView.setOnClickListener((OnClickListener)(new ForecastListAdapter$ViewHolder$bindForecast$$inlined$with$lambda$1(forecast, this)));
      }

      @NotNull
      public final Function1 getItemClick() {
         return this.itemClick;
      }

      public ViewHolder(@NotNull View view, @NotNull Function1 itemClick) {
         Intrinsics.checkParameterIsNotNull(view, "view");
         Intrinsics.checkParameterIsNotNull(itemClick, "itemClick");
         super(view);
         this.itemClick = itemClick;
      }
   }
```